### PR TITLE
Fixed issue w/ 'SECRET_KEY' env var

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM python
 
 WORKDIR /usr/src/app
-COPY . .
+COPY ./app .
 RUN pip install --no-cache-dir -r requirements.txt
 
 EXPOSE 8000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,12 +8,17 @@ services:
     restart: always
     ports:
       - "8000:8000"
-    volumes:
-      - ./config.ini:/usr/src/config.ini
-      - ./app:/usr/src/app
     depends_on:
       - db
   db:
     image: postgres
     env_file: .env
     restart: always
+    volumes:
+      - type: volume
+        source: db_data
+        target: /var/lib/postgres/data
+
+volumes:
+  app:
+  db_data:


### PR DESCRIPTION
In `.env`, _do not_ surround value with quotes, e.g.:

```sh
SECRET_KEY=secret_key
```

Instead of 

```
SECRET_KEY='secret_key'
```